### PR TITLE
pyjags particular about version now

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ conda activate mcmc
 
 Note that you may need or want to create a separate environment for pyjags using `conda`:
 ```bash
-conda create -n jags python=3 numpy scipy
+conda create -n jags python=3.8 numpy
 conda activate jags
 pip install pyjags
 ```


### PR DESCRIPTION
PyJAGS does not appear to offer continued support for newer versions of Python. Additionally, I observed that its installation requires only NumPy, not SciPy. See the setup file at https://github.com/michaelnowotny/pyjags/blob/master/setup.py.

Otherwise, the `model2b_experiment2.py` runs fine, having been computationally reproduced recovery on two devices.